### PR TITLE
add npu suport for trainer

### DIFF
--- a/src/lightning/__setup__.py
+++ b/src/lightning/__setup__.py
@@ -94,7 +94,7 @@ def _setup_args() -> Dict[str, Any]:
         "include_package_data": True,
         "zip_safe": False,
         "keywords": ["deep learning", "pytorch", "AI"],
-        "python_requires": ">=3.9",
+        "python_requires": ">=3.8",
         "entry_points": {
             "console_scripts": [
                 "fabric = lightning.fabric.cli:_main",

--- a/src/lightning/pytorch/accelerators/__init__.py
+++ b/src/lightning/pytorch/accelerators/__init__.py
@@ -18,6 +18,7 @@ from lightning.fabric.utilities.registry import _register_classes
 from lightning.pytorch.accelerators.accelerator import Accelerator
 from lightning.pytorch.accelerators.cpu import CPUAccelerator  # noqa: F401
 from lightning.pytorch.accelerators.cuda import CUDAAccelerator  # noqa: F401
+from lightning.pytorch.accelerators.npu import NPUAccelerator  # noqa: F401
 from lightning.pytorch.accelerators.mps import MPSAccelerator  # noqa: F401
 from lightning.pytorch.accelerators.xla import XLAAccelerator  # noqa: F401
 

--- a/src/lightning/pytorch/accelerators/accelerator.py
+++ b/src/lightning/pytorch/accelerators/accelerator.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from abc import ABC
+from contextlib import nullcontext
 from typing import Any, Dict
 
 import lightning.pytorch as pl
@@ -45,3 +46,9 @@ class Accelerator(_Accelerator, ABC):
 
         """
         raise NotImplementedError
+
+    def get_distribute_name(self) -> str:
+        return "gloo"
+
+    def get_stream_context(self, device_id: Any) -> Any:
+        return nullcontext()

--- a/src/lightning/pytorch/accelerators/cuda.py
+++ b/src/lightning/pytorch/accelerators/cuda.py
@@ -15,6 +15,7 @@ import logging
 import os
 import shutil
 import subprocess
+from contextlib import nullcontext
 from typing import Any, Dict, List, Optional, Union
 
 import torch
@@ -103,6 +104,14 @@ class CUDAAccelerator(Accelerator):
     @override
     def is_available() -> bool:
         return num_cuda_devices() > 0
+
+    @override
+    def get_distribute_name(self) -> str:
+        return "nccl"
+
+    @override
+    def get_stream_context(self, device_id: List[int]) -> Any:
+        return torch.cuda.stream(torch.cuda.Stream()) if device_id is not None else nullcontext()
 
     @classmethod
     @override

--- a/src/lightning/pytorch/accelerators/npu.py
+++ b/src/lightning/pytorch/accelerators/npu.py
@@ -1,0 +1,110 @@
+# Copyright The Lightning AI team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from contextlib import nullcontext
+from typing import Any, Dict, List, Optional, Union
+
+import torch
+from typing_extensions import override
+
+from lightning.fabric.accelerators import _AcceleratorRegistry
+from lightning.fabric.utilities.types import _DEVICE
+from lightning.pytorch.accelerators.accelerator import Accelerator
+from lightning.pytorch.utilities.exceptions import MisconfigurationException
+
+
+class NPUAccelerator(Accelerator):
+    """Accelerator for Ascend NPU devices."""
+
+    @override
+    def setup_device(self, device: torch.device) -> None:
+        """
+        Raises:
+            MisconfigurationException:
+                If the selected device is not NPU.
+        """
+        if device.type != "npu":
+            raise MisconfigurationException(f"Device should be NPU, got {device} instead.")
+        torch.npu.set_device(device)
+
+    @override
+    def get_device_stats(self, device: _DEVICE) -> Dict[str, Any]:
+        return torch.npu.memory_stats(device)
+
+    @override
+    def teardown(self) -> None:
+        torch.npu.empty_cache()
+
+    @staticmethod
+    @override
+    def parse_devices(devices: Union[int, str, List[int]]) -> Optional[List[int]]:
+        """Accelerator device parsing logic.
+        -1 or '-1' means use all npus.
+        """
+
+        if isinstance(devices, list):
+            return devices
+        if isinstance(devices, str):
+            if devices == "-1":
+                return list(range(torch.npu.device_count()))
+            if "," in devices:
+                return [int(x.strip()) for x in devices.split(",") if len(x) > 0]
+            return list(range(int(devices.strip())))
+        if isinstance(devices, int):
+            if devices == -1:
+                return list(range(torch.npu.device_count()))
+            return list(range(devices))
+
+        return None
+
+    @staticmethod
+    @override
+    def get_parallel_devices(devices: List[int]) -> List[torch.device]:
+        """Gets parallel devices for the Accelerator."""
+
+        return [torch.device("npu", i) for i in devices]
+
+    @staticmethod
+    @override
+    def auto_device_count() -> int:
+        """Get the devices when set to auto."""
+
+        return torch.npu.device_count()
+
+    @staticmethod
+    @override
+    def is_available() -> bool:
+        try:
+            import torch_npu  # noqa: F401
+
+            return torch.npu.device_count() > 0
+        except ImportError:
+            # NPU may raise these exceptions if it's not properly configured.
+            return False
+
+    @override
+    def get_distribute_name(self) -> str:
+        return "hccl"
+
+    @override
+    def get_stream_context(self, device_id: List[int]) -> Any:
+        return torch.npu.stream(torch.npu.Stream()) if device_id is not None else nullcontext()
+
+    @classmethod
+    @override
+    def register_accelerators(cls, accelerator_registry: _AcceleratorRegistry) -> None:
+        accelerator_registry.register(
+            "npu",
+            cls,
+            description=cls.__name__,
+        )

--- a/src/lightning/pytorch/strategies/ddp.py
+++ b/src/lightning/pytorch/strategies/ddp.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
-from contextlib import nullcontext
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Literal, Optional, Union
 
@@ -31,7 +30,6 @@ from lightning.fabric.plugins.collectives.torch_collective import default_pg_tim
 from lightning.fabric.strategies import _StrategyRegistry
 from lightning.fabric.utilities.distributed import (
     _distributed_is_initialized,
-    _get_default_process_group_backend_for_device,
     _init_dist_connection,
     _sync_ddp_if_available,
 )
@@ -190,7 +188,8 @@ class DDPStrategy(ParallelStrategy):
         device_ids = self.determine_ddp_device_ids()
         log.debug(f"setting up DDP model with device ids: {device_ids}, kwargs: {self._ddp_kwargs}")
         # https://pytorch.org/docs/stable/notes/cuda.html#id5
-        ctx = torch.cuda.stream(torch.cuda.Stream()) if device_ids is not None else nullcontext()
+        assert self.accelerator is not None
+        ctx = self.accelerator.get_stream_context(device_ids)
         with ctx:
             return DistributedDataParallel(module=model, device_ids=device_ids, **self._ddp_kwargs)
 
@@ -203,8 +202,8 @@ class DDPStrategy(ParallelStrategy):
         _init_dist_connection(self.cluster_environment, self._process_group_backend, timeout=self._timeout)
 
     def _get_process_group_backend(self) -> str:
-        return self._process_group_backend or _get_default_process_group_backend_for_device(self.root_device)
-
+        assert self.accelerator is not None
+        return self._process_group_backend or self.accelerator.get_distribute_name()
     def set_world_ranks(self) -> None:
         if self.cluster_environment is not None:
             self.cluster_environment.set_global_rank(self.node_rank * self.num_processes + self.local_rank)

--- a/src/lightning/pytorch/strategies/deepspeed.py
+++ b/src/lightning/pytorch/strategies/deepspeed.py
@@ -40,6 +40,7 @@ from lightning.fabric.utilities.optimizer import _optimizers_to_device
 from lightning.fabric.utilities.seed import reset_seed
 from lightning.fabric.utilities.types import _PATH
 from lightning.pytorch.accelerators.cuda import CUDAAccelerator
+from lightning.pytorch.accelerators.npu import NPUAccelerator
 from lightning.pytorch.core.optimizer import _init_optimizers_and_lr_schedulers
 from lightning.pytorch.plugins.precision import Precision
 from lightning.pytorch.strategies.ddp import DDPStrategy
@@ -316,10 +317,10 @@ class DeepSpeedStrategy(DDPStrategy):
 
     @override
     def setup_environment(self) -> None:
-        if not isinstance(self.accelerator, CUDAAccelerator):
+        if not isinstance(self.accelerator, (CUDAAccelerator, NPUAccelerator)):
             raise RuntimeError(
-                f"The DeepSpeed strategy is only supported on CUDA GPUs but `{self.accelerator.__class__.__name__}`"
-                " is used."
+                "The DeepSpeed strategy is only supported on CUDA GPUs or Ascend NPUs but"
+                " `{self.accelerator.__class__.__name__}` is used."
             )
         super().setup_environment()
 

--- a/src/lightning/pytorch/strategies/fsdp.py
+++ b/src/lightning/pytorch/strategies/fsdp.py
@@ -62,7 +62,6 @@ from lightning.fabric.strategies.fsdp import (
 from lightning.fabric.strategies.model_parallel import _load_raw_module_state
 from lightning.fabric.utilities.distributed import (
     _distributed_is_initialized,
-    _get_default_process_group_backend_for_device,
     _init_dist_connection,
     _sync_ddp_if_available,
 )
@@ -275,8 +274,9 @@ class FSDPStrategy(ParallelStrategy):
             self.kwargs["device_mesh"] = init_device_mesh("cuda", self.kwargs["device_mesh"])
 
     def _get_process_group_backend(self) -> str:
-        return self._process_group_backend or _get_default_process_group_backend_for_device(self.root_device)
-
+        assert self.accelerator is not None
+        return self._process_group_backend or self.accelerator.get_distribute_name()
+        
     def set_world_ranks(self) -> None:
         if self.cluster_environment is not None:
             self.cluster_environment.set_global_rank(self.node_rank * self.num_processes + self.local_rank)

--- a/src/lightning/pytorch/trainer/setup.py
+++ b/src/lightning/pytorch/trainer/setup.py
@@ -17,7 +17,7 @@ from typing import Optional, Union
 
 import lightning.pytorch as pl
 from lightning.fabric.utilities.warnings import PossibleUserWarning
-from lightning.pytorch.accelerators import CUDAAccelerator, MPSAccelerator, XLAAccelerator
+from lightning.pytorch.accelerators import CUDAAccelerator, NPUAccelerator, MPSAccelerator, XLAAccelerator
 from lightning.pytorch.loggers.logger import DummyLogger
 from lightning.pytorch.profilers import (
     AdvancedProfiler,
@@ -168,6 +168,9 @@ def _log_device_info(trainer: "pl.Trainer") -> None:
         hpu_available = False
     rank_zero_info(f"HPU available: {hpu_available}, using: {num_hpus} HPUs")
 
+    number_npu_cores = trainer.num_devices if isinstance(trainer.accelerator, NPUAccelerator) else 0
+    rank_zero_info(f"NPU available: {NPUAccelerator.is_available()}, using: {number_npu_cores} NPU cores")
+
     if (
         CUDAAccelerator.is_available()
         and not isinstance(trainer.accelerator, CUDAAccelerator)
@@ -187,3 +190,6 @@ def _log_device_info(trainer: "pl.Trainer") -> None:
 
         if HPUAccelerator.is_available() and not isinstance(trainer.accelerator, HPUAccelerator):
             rank_zero_warn("HPU available but not used. You can set it by doing `Trainer(accelerator='hpu')`.")
+    
+    if NPUAccelerator.is_available() and not isinstance(trainer.accelerator, NPUAccelerator):
+        rank_zero_warn("NPU available but not used. You can set it by doing `Trainer(accelerator='npu')`.")


### PR DESCRIPTION
# NPU 使用样例

```python
# main.py
# ! pip install torchvision
import torch, torch.nn as nn, torch.utils.data as data, torchvision as tv, torch.nn.functional as F
import lightning as L

# --------------------------------
# Step 1: Define a LightningModule
# --------------------------------
# A LightningModule (nn.Module subclass) defines a full *system*
# (ie: an LLM, diffusion model, autoencoder, or simple image classifier).


class LitAutoEncoder(L.LightningModule):
    def __init__(self):
        super().__init__()
        self.encoder = nn.Sequential(nn.Linear(28 * 28, 128), nn.ReLU(), nn.Linear(128, 3))
        self.decoder = nn.Sequential(nn.Linear(3, 128), nn.ReLU(), nn.Linear(128, 28 * 28))

    def forward(self, x):
        # in lightning, forward defines the prediction/inference actions
        embedding = self.encoder(x)
        return embedding

    def training_step(self, batch, batch_idx):
        # training_step defines the train loop. It is independent of forward
        x, y = batch
        x = x.view(x.size(0), -1)
        z = self.encoder(x)
        x_hat = self.decoder(z)
        loss = F.mse_loss(x_hat, x)
        self.log("train_loss", loss)
        return loss

    def configure_optimizers(self):
        optimizer = torch.optim.Adam(self.parameters(), lr=1e-3)
        return optimizer


# -------------------
# Step 2: Define data
# -------------------
dataset = tv.datasets.MNIST(".", download=True, transform=tv.transforms.ToTensor())
train, val = data.random_split(dataset, [55000, 5000])

# -------------------
# Step 3: Train
# -------------------
autoencoder = LitAutoEncoder()
trainer = L.Trainer(accelerator='npu', devices='0,1', max_epochs=1, strategy='deepspeed')
trainer.fit(autoencoder, data.DataLoader(train), data.DataLoader(val))
```

# 特性支持列表

## LightningModule

支持用户自定义网络结构、前向传播、train loop和优化器。

上述使用样例中通过`def init(self):` 定义网络架构(model)；`def forward(self, x):`定义推理、预测的前向传播; `def training_step(self, batch, batch_idx):`定义train loop; `def configure_optimizers(self):` 定义优化器。

## accelerator

当前已支持NPU，使用样例

```python
trainer = L.Trainer(accelerator='npu', devices=2)
```

## strategy

支持`ddp`，`deepspeed`和`fsdp`三种方式

```python
trainer = L.Trainer(accelerator='npu', devices=2, strategy='deepspeed')
```

## devices

支持`str`与`int`两种输入

- 可通过`str`传入当前可用卡，需要从0卡开始按顺序输入，
  
- 也可通过`int`传入使用卡的数量
  

```python
# str
trainer = L.Trainer(accelerator='npu', devices='0,1', strategy='deepspeed')

# int
trainer = L.Trainer(accelerator='npu', devices=2, strategy='deepspeed')
```

## 训练超参

- `max_epochs`：最大训练轮数。
  
- `min_epochs`：最小训练轮数。
  
- `max_steps`：每轮最大训练步数。
  
- `min_steps`：每轮最小训练步数。
  

## EarlyStopping

监控某个指标，当其不再提升时就停止训练。

```python
from lightning.pytorch.callbacks import EarlyStopping
early_stopping = EarlyStopping('train_loss')
trainer = Trainer(callbacks=[early_stopping])
```

## precision

支持16位精度计算

```python
trainer = Trainer(precision=16)
```